### PR TITLE
Add keyword suggestion page

### DIFF
--- a/src/app/api/suggest/route.ts
+++ b/src/app/api/suggest/route.ts
@@ -1,0 +1,31 @@
+import { AppStoreClient } from "app-store-client";
+import { NextRequest, NextResponse } from "next/server";
+import { countryMap } from "@/lib/countryMap";
+
+export async function GET(request: NextRequest) {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const term = searchParams.get("term");
+    const countryCode = searchParams.get("country") || "US";
+    const language = searchParams.get("language") || "en-us";
+
+    if (!term) {
+      return NextResponse.json({ error: "キーワードが必要です" }, { status: 400 });
+    }
+
+    if (!countryMap[countryCode]) {
+      return NextResponse.json({ error: `無効な国コード: ${countryCode}` }, { status: 400 });
+    }
+
+    const country = countryMap[countryCode];
+
+    const client = new AppStoreClient({ country, language });
+    const suggestions = await client.getSuggestedSearchTerms({ term });
+
+    return NextResponse.json({ suggestions });
+  } catch (error) {
+    console.error("Suggest API error:", error);
+    const errorMessage = error instanceof Error ? error.message : "サジェスト取得中にエラーが発生しました";
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -228,6 +229,11 @@ export default function Home() {
       <h1 className="text-3xl font-bold mb-8 text-center">
         アプリアイデア発想ツール
       </h1>
+      <p className="text-center mb-8">
+        <Link href="/suggest" className="text-primary underline">
+          検索サジェストページへ
+        </Link>
+      </p>
 
       {/* Toast Notification */}
       {toast && (

--- a/src/app/suggest/page.tsx
+++ b/src/app/suggest/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React, { useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function SuggestPage() {
+  const [term, setTerm] = useState("");
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSuggestions = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!term.trim()) {
+      setError("キーワードを入力してください");
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/suggest?term=${encodeURIComponent(term)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || "サジェスト取得中にエラーが発生しました");
+      }
+      setSuggestions(data.suggestions || []);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "エラーが発生しました";
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-4 text-center">検索サジェスト</h1>
+      <p className="text-center mb-6">
+        <Link href="/" className="text-primary underline">
+          メインページへ戻る
+        </Link>
+      </p>
+
+      <Card className="mb-8">
+        <CardHeader>
+          <h2 className="text-xl font-bold">キーワード候補を入力</h2>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={fetchSuggestions} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="term">キーワード</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="term"
+                  value={term}
+                  onChange={(e) => setTerm(e.target.value)}
+                  placeholder="例: メモ"
+                />
+                <Button type="submit" disabled={isLoading}>
+                  取得
+                </Button>
+              </div>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
+          {error}
+        </div>
+      )}
+
+      {isLoading && (
+        <div className="flex justify-center my-8">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary"></div>
+        </div>
+      )}
+
+      {suggestions.length > 0 && (
+        <div>
+          <h2 className="text-xl font-bold mb-4">サジェスト結果</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            {suggestions.map((s, i) => (
+              <li key={i}>{s}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route for suggest search terms
- add new page to query suggested keywords
- link to suggestion page from the main page

## Testing
- `npm run lint` *(fails: next not found)*